### PR TITLE
Add provider-specific cache configuration overloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ Package versions for **core**, **Redis**, **Garnet**, and **EntityFramework** ar
 
 ### Added
 
-- (none yet)
+- Provider-specific configuration overloads for cache registration:
+  - `UseMemoryCache(Action<MemoryRequestOutputCacheOptions>)`
+  - `UseRedisCache(Action<RedisRequestOutputCacheOptions>)` / `UseGarnetCache(Action<GarnetRequestOutputCacheOptions>)`
+  - Optional `InstanceName`, `Database`, `ConfigurationOptions`, and `DefaultExpirationInSeconds`
+  - Existing string / parameterless overloads unchanged (delegate to the new APIs)
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Invalidation is **tag-based**: associate tags with cached requests, then evict b
 | **CQRS eviction bus** | Cross-DI / split-host invalidation via in-process bus, Redis/Garnet Pub/Sub, or custom Rabbit/Kafka/MassTransit adapters. |
 | **Command eviction attribute** | `[RequestOutputCacheEvict]` publishes or evicts tags after a successful command. |
 | **Deterministic cache keys** | Key = `{RequestTypeName}:{SHA-256(JSON)}` from the serialized request payload. |
-| **Per-request expiration** | `expirationInSeconds` on the attribute (default **300**); `0` means no absolute expiration. |
+| **Per-request expiration** | `expirationInSeconds` on the attribute (default **300**); `0` means no absolute expiration. Provider `DefaultExpirationInSeconds` can replace the library default when the attribute omits an explicit value. |
 | **Flush all** | `IRequestOutputCacheInvalidator.FlushAll` clears the entire cache store for the provider. |
 | **Clear on startup** | Optional `ClearCacheOnStartup()` during DI configuration. |
 | **FluentResults** | Cache get/set/evict APIs return `Result` / `Result<T>` for success and failure paths. |
@@ -158,12 +158,36 @@ builder.Services.AddMediatROutputCache(opt =>
 });
 ```
 
+Optional provider defaults (applied when the attribute omits an explicit `expirationInSeconds`, i.e. uses the library constant **300**):
+
+```csharp
+builder.Services.AddMediatROutputCache(opt =>
+{
+    opt.UseMemoryCache(o => o.DefaultExpirationInSeconds = 600);
+});
+```
+
 ### Redis
 
 ```csharp
 builder.Services.AddMediatROutputCache(opt =>
 {
     opt.UseRedisCache("localhost:6379,password=YourRedisPassword");
+});
+```
+
+Provider-specific options (`InstanceName`, `Database`, default TTL, or advanced `ConfigurationOptions`):
+
+```csharp
+builder.Services.AddMediatROutputCache(opt =>
+{
+    opt.UseRedisCache(o =>
+    {
+        o.ConnectionString = builder.Configuration.GetConnectionString("Redis")!;
+        o.InstanceName = "my-app:";
+        o.Database = 1;
+        o.DefaultExpirationInSeconds = 300;
+    });
 });
 ```
 
@@ -176,6 +200,9 @@ builder.Services.AddMediatROutputCache(opt =>
 });
 ```
 
+Same nested options pattern as Redis via `UseGarnetCache(Action<GarnetRequestOutputCacheOptions>)`.
+
+> **TTL precedence:** an explicit `expirationInSeconds` on `[RequestOutputCache]` always wins (including `0` for never expire). Provider `DefaultExpirationInSeconds` only replaces the library default when the attribute uses the constructor default (**300**). Explicit `300` is indistinguishable from that default.
 ### Entity Framework auto-evict
 
 After a successful `SaveChanges` / `SaveChangesAsync`, the interceptor collects distinct entity CLR type **names** and calls `EvictByTagsAsync` with those names. Request tags must match (typically `nameof(YourEntity)`).

--- a/src/NexGen.MediatR.Extensions.Caching.Garnet/Configurations/GarnetConfigurationExtensions.cs
+++ b/src/NexGen.MediatR.Extensions.Caching.Garnet/Configurations/GarnetConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using NexGen.MediatR.Extensions.Caching.Constants;
 using NexGen.MediatR.Extensions.Caching.Contracts;
 using NexGen.MediatR.Extensions.Caching.Enums;
 using NexGen.MediatR.Extensions.Caching.Garnet.Containers;
+using StackExchange.Redis;
 
 namespace NexGen.MediatR.Extensions.Caching.Garnet.Configurations;
 
@@ -23,26 +24,83 @@ public static class GarnetConfigurationExtensions
     /// <exception cref="InvalidOperationException">Thrown if a cache type has already been configured.</exception>
     public static void UseGarnetCache(this RequestOutputCacheConfigurationOption options, string connectionString)
     {
-        if (options == null)
-            throw new ArgumentNullException(nameof(options));
-
-        if (options.RequestOutputCacheType != default)
-            throw new InvalidOperationException(ErrorMessages.AlreadyConfigured);
+        ArgumentNullException.ThrowIfNull(options);
 
         if (string.IsNullOrWhiteSpace(connectionString))
             throw new ArgumentException(ErrorMessages.EmptyConnectionString, nameof(connectionString));
 
+        options.UseGarnetCache(garnet => garnet.ConnectionString = connectionString);
+    }
+
+    /// <summary>
+    /// Configures the library to use Garnet cache for MediatR request responses.
+    /// </summary>
+    /// <param name="options">The output cache configuration options.</param>
+    /// <param name="configure">Action used to configure Garnet provider options.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> or <paramref name="configure"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if neither a connection string nor configuration options are provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if a cache type has already been configured.</exception>
+    public static void UseGarnetCache(
+        this RequestOutputCacheConfigurationOption options,
+        Action<GarnetRequestOutputCacheOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (options.RequestOutputCacheType != default)
+            throw new InvalidOperationException(ErrorMessages.AlreadyConfigured);
+
+        var garnetOptions = new GarnetRequestOutputCacheOptions();
+        configure(garnetOptions);
+
+        if (garnetOptions.ConfigurationOptions is null && string.IsNullOrWhiteSpace(garnetOptions.ConnectionString))
+            throw new ArgumentException(ErrorMessages.EmptyConnectionString, nameof(configure));
+
         options.RequestOutputCacheType = RequestOutputCacheType.GarnetCache;
 
-        // Configure StackExchange.Redis cache (used by Garnet)
-        options.Services.AddStackExchangeRedisCache(garnetCacheOptions =>
+        RequestOutputCacheDefaultsRegistration.Apply(options.Services, garnetOptions.DefaultExpirationInSeconds);
+
+        options.Services.AddStackExchangeRedisCache(cacheOptions =>
         {
-            garnetCacheOptions.Configuration = connectionString;
+            ApplyDistributedCacheOptions(
+                cacheOptions,
+                garnetOptions.ConnectionString,
+                garnetOptions.InstanceName,
+                garnetOptions.Database,
+                garnetOptions.ConfigurationOptions);
         });
 
-        // Register the Garnet request output cache implementation
         options.Services.AddScoped(typeof(IRequestOutputCache<,>), typeof(GarnetRequestOutputCache<,>));
         options.Services.AddScoped<IRequestOutputCacheInvalidator, GarnetRequestOutputCache<IRequest<object>, object>>();
         options.Services.AddScoped<IRequestOutputCacheContainer, GarnetOutputCacheContainer>();
+    }
+
+    internal static void ApplyDistributedCacheOptions(
+        Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions cacheOptions,
+        string? connectionString,
+        string? instanceName,
+        int? database,
+        ConfigurationOptions? configurationOptions)
+    {
+        cacheOptions.InstanceName = instanceName;
+
+        if (configurationOptions is not null)
+        {
+            if (database.HasValue)
+                configurationOptions.DefaultDatabase = database;
+
+            cacheOptions.ConfigurationOptions = configurationOptions;
+            return;
+        }
+
+        if (database.HasValue)
+        {
+            var parsed = ConfigurationOptions.Parse(connectionString!);
+            parsed.DefaultDatabase = database;
+            cacheOptions.ConfigurationOptions = parsed;
+            return;
+        }
+
+        cacheOptions.Configuration = connectionString;
     }
 }

--- a/src/NexGen.MediatR.Extensions.Caching.Garnet/Configurations/GarnetRequestOutputCacheOptions.cs
+++ b/src/NexGen.MediatR.Extensions.Caching.Garnet/Configurations/GarnetRequestOutputCacheOptions.cs
@@ -1,0 +1,36 @@
+using StackExchange.Redis;
+
+namespace NexGen.MediatR.Extensions.Caching.Garnet.Configurations;
+
+/// <summary>
+/// Configuration options for the Garnet MediatR request output cache provider.
+/// </summary>
+public sealed class GarnetRequestOutputCacheOptions
+{
+    /// <summary>
+    /// Garnet connection string. Required unless <see cref="ConfigurationOptions"/> is set.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Optional key prefix applied by <c>IDistributedCache</c> (<c>RedisCacheOptions.InstanceName</c>).
+    /// </summary>
+    public string? InstanceName { get; set; }
+
+    /// <summary>
+    /// Optional Redis-compatible database index (<c>ConfigurationOptions.DefaultDatabase</c>).
+    /// </summary>
+    public int? Database { get; set; }
+
+    /// <summary>
+    /// Optional default cache lifetime in seconds for requests that omit an explicit
+    /// <c>expirationInSeconds</c> on the cache attribute.
+    /// </summary>
+    public int? DefaultExpirationInSeconds { get; set; }
+
+    /// <summary>
+    /// Optional advanced StackExchange.Redis configuration.
+    /// When set, takes precedence over <see cref="ConnectionString"/> for connection settings.
+    /// </summary>
+    public ConfigurationOptions? ConfigurationOptions { get; set; }
+}

--- a/src/NexGen.MediatR.Extensions.Caching.Redis/Configurations/RedisConfigurationExtensions.cs
+++ b/src/NexGen.MediatR.Extensions.Caching.Redis/Configurations/RedisConfigurationExtensions.cs
@@ -5,6 +5,7 @@ using NexGen.MediatR.Extensions.Caching.Constants;
 using NexGen.MediatR.Extensions.Caching.Contracts;
 using NexGen.MediatR.Extensions.Caching.Enums;
 using NexGen.MediatR.Extensions.Caching.Redis.Containers;
+using StackExchange.Redis;
 
 namespace NexGen.MediatR.Extensions.Caching.Redis.Configurations;
 
@@ -23,26 +24,83 @@ public static class RedisConfigurationExtensions
     /// <exception cref="InvalidOperationException">Thrown if a cache type has already been configured.</exception>
     public static void UseRedisCache(this RequestOutputCacheConfigurationOption options, string connectionString)
     {
-        if (options == null)
-            throw new ArgumentNullException(nameof(options));
-
-        if (options.RequestOutputCacheType != default)
-            throw new InvalidOperationException(ErrorMessages.AlreadyConfigured);
+        ArgumentNullException.ThrowIfNull(options);
 
         if (string.IsNullOrWhiteSpace(connectionString))
             throw new ArgumentException(ErrorMessages.EmptyConnectionString, nameof(connectionString));
 
+        options.UseRedisCache(redis => redis.ConnectionString = connectionString);
+    }
+
+    /// <summary>
+    /// Configures the library to use Redis cache for MediatR request responses.
+    /// </summary>
+    /// <param name="options">The output cache configuration options.</param>
+    /// <param name="configure">Action used to configure Redis provider options.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="options"/> or <paramref name="configure"/> is null.</exception>
+    /// <exception cref="ArgumentException">Thrown if neither a connection string nor configuration options are provided.</exception>
+    /// <exception cref="InvalidOperationException">Thrown if a cache type has already been configured.</exception>
+    public static void UseRedisCache(
+        this RequestOutputCacheConfigurationOption options,
+        Action<RedisRequestOutputCacheOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(options);
+        ArgumentNullException.ThrowIfNull(configure);
+
+        if (options.RequestOutputCacheType != default)
+            throw new InvalidOperationException(ErrorMessages.AlreadyConfigured);
+
+        var redisOptions = new RedisRequestOutputCacheOptions();
+        configure(redisOptions);
+
+        if (redisOptions.ConfigurationOptions is null && string.IsNullOrWhiteSpace(redisOptions.ConnectionString))
+            throw new ArgumentException(ErrorMessages.EmptyConnectionString, nameof(configure));
+
         options.RequestOutputCacheType = RequestOutputCacheType.RedisCache;
 
-        // Configure StackExchange.Redis cache
-        options.Services.AddStackExchangeRedisCache(redisOptions =>
+        RequestOutputCacheDefaultsRegistration.Apply(options.Services, redisOptions.DefaultExpirationInSeconds);
+
+        options.Services.AddStackExchangeRedisCache(cacheOptions =>
         {
-            redisOptions.Configuration = connectionString;
+            ApplyDistributedCacheOptions(
+                cacheOptions,
+                redisOptions.ConnectionString,
+                redisOptions.InstanceName,
+                redisOptions.Database,
+                redisOptions.ConfigurationOptions);
         });
 
-        // Register the Redis request output cache implementation
         options.Services.AddScoped(typeof(IRequestOutputCache<,>), typeof(RedisRequestOutputCache<,>));
         options.Services.AddScoped<IRequestOutputCacheInvalidator, RedisRequestOutputCache<IRequest<object>, object>>();
         options.Services.AddScoped<IRequestOutputCacheContainer, RedisOutputCacheContainer>();
+    }
+
+    internal static void ApplyDistributedCacheOptions(
+        Microsoft.Extensions.Caching.StackExchangeRedis.RedisCacheOptions cacheOptions,
+        string? connectionString,
+        string? instanceName,
+        int? database,
+        ConfigurationOptions? configurationOptions)
+    {
+        cacheOptions.InstanceName = instanceName;
+
+        if (configurationOptions is not null)
+        {
+            if (database.HasValue)
+                configurationOptions.DefaultDatabase = database;
+
+            cacheOptions.ConfigurationOptions = configurationOptions;
+            return;
+        }
+
+        if (database.HasValue)
+        {
+            var parsed = ConfigurationOptions.Parse(connectionString!);
+            parsed.DefaultDatabase = database;
+            cacheOptions.ConfigurationOptions = parsed;
+            return;
+        }
+
+        cacheOptions.Configuration = connectionString;
     }
 }

--- a/src/NexGen.MediatR.Extensions.Caching.Redis/Configurations/RedisRequestOutputCacheOptions.cs
+++ b/src/NexGen.MediatR.Extensions.Caching.Redis/Configurations/RedisRequestOutputCacheOptions.cs
@@ -1,0 +1,36 @@
+using StackExchange.Redis;
+
+namespace NexGen.MediatR.Extensions.Caching.Redis.Configurations;
+
+/// <summary>
+/// Configuration options for the Redis MediatR request output cache provider.
+/// </summary>
+public sealed class RedisRequestOutputCacheOptions
+{
+    /// <summary>
+    /// Redis connection string. Required unless <see cref="ConfigurationOptions"/> is set.
+    /// </summary>
+    public string? ConnectionString { get; set; }
+
+    /// <summary>
+    /// Optional key prefix applied by <c>IDistributedCache</c> (<c>RedisCacheOptions.InstanceName</c>).
+    /// </summary>
+    public string? InstanceName { get; set; }
+
+    /// <summary>
+    /// Optional Redis database index (<c>ConfigurationOptions.DefaultDatabase</c>).
+    /// </summary>
+    public int? Database { get; set; }
+
+    /// <summary>
+    /// Optional default cache lifetime in seconds for requests that omit an explicit
+    /// <c>expirationInSeconds</c> on the cache attribute.
+    /// </summary>
+    public int? DefaultExpirationInSeconds { get; set; }
+
+    /// <summary>
+    /// Optional advanced StackExchange.Redis configuration.
+    /// When set, takes precedence over <see cref="ConnectionString"/> for connection settings.
+    /// </summary>
+    public ConfigurationOptions? ConfigurationOptions { get; set; }
+}

--- a/src/NexGen.MediatR.Extensions.Caching/Behaviors/RequestOutputCacheBehavior.cs
+++ b/src/NexGen.MediatR.Extensions.Caching/Behaviors/RequestOutputCacheBehavior.cs
@@ -1,5 +1,7 @@
 using MediatR;
 using NexGen.MediatR.Extensions.Caching.Attributes;
+using NexGen.MediatR.Extensions.Caching.Configurations;
+using NexGen.MediatR.Extensions.Caching.Constants;
 using NexGen.MediatR.Extensions.Caching.Contracts;
 
 namespace NexGen.MediatR.Extensions.Caching.Behaviors;
@@ -14,6 +16,7 @@ public class RequestOutputCacheBehavior<TRequest, TResponse>
     : IPipelineBehavior<TRequest, TResponse> where TRequest : IRequest<TResponse>
 {
     private readonly IRequestOutputCache<TRequest, TResponse> _requestOutputCache;
+    private readonly RequestOutputCacheDefaults _defaults;
 
     /// <summary>
     /// Initializes a new instance of the <see cref="RequestOutputCacheBehavior{TRequest, TResponse}"/> class.
@@ -21,9 +24,16 @@ public class RequestOutputCacheBehavior<TRequest, TResponse>
     /// <param name="requestOutputCache">
     /// The cache service that handles storing and retrieving request responses.
     /// </param>
-    public RequestOutputCacheBehavior(IRequestOutputCache<TRequest, TResponse> requestOutputCache)
+    /// <param name="defaults">
+    /// Optional library defaults. When <see cref="RequestOutputCacheDefaults.DefaultExpirationInSeconds"/> is set,
+    /// it replaces the attribute constructor default expiration.
+    /// </param>
+    public RequestOutputCacheBehavior(
+        IRequestOutputCache<TRequest, TResponse> requestOutputCache,
+        RequestOutputCacheDefaults? defaults = null)
     {
         _requestOutputCache = requestOutputCache;
+        _defaults = defaults ?? new RequestOutputCacheDefaults();
     }
 
     /// <summary>
@@ -54,8 +64,19 @@ public class RequestOutputCacheBehavior<TRequest, TResponse>
         var result = await next(cancellationToken);
 
         var tags = attribute.Tags;
-        var expiration = attribute.ExpirationInSeconds;
+        var expiration = ResolveExpiration(attribute.ExpirationInSeconds);
         await _requestOutputCache.SetAsync(request, result, tags, expiration, cancellationToken).ConfigureAwait(false);
         return result;
+    }
+
+    private int ResolveExpiration(int attributeExpirationInSeconds)
+    {
+        if (attributeExpirationInSeconds == RequestCacheConstants.DefaultExpirationInSeconds
+            && _defaults.DefaultExpirationInSeconds is int providerDefault)
+        {
+            return providerDefault;
+        }
+
+        return attributeExpirationInSeconds;
     }
 }

--- a/src/NexGen.MediatR.Extensions.Caching/Configurations/MemoryRequestOutputCacheOptions.cs
+++ b/src/NexGen.MediatR.Extensions.Caching/Configurations/MemoryRequestOutputCacheOptions.cs
@@ -1,0 +1,13 @@
+namespace NexGen.MediatR.Extensions.Caching.Configurations;
+
+/// <summary>
+/// Configuration options for the in-memory MediatR request output cache provider.
+/// </summary>
+public sealed class MemoryRequestOutputCacheOptions
+{
+    /// <summary>
+    /// Optional default cache lifetime in seconds for requests that omit an explicit
+    /// <c>expirationInSeconds</c> on <see cref="Attributes.RequestOutputCacheAttribute"/>.
+    /// </summary>
+    public int? DefaultExpirationInSeconds { get; set; }
+}

--- a/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheConfiguration.cs
+++ b/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheConfiguration.cs
@@ -34,6 +34,7 @@ public static class RequestOutputCacheConfiguration
     /// <returns>The updated <see cref="IServiceCollection"/>.</returns>
     private static IServiceCollection AddMediatROutputCache(this IServiceCollection services)
     {
+        RequestOutputCacheDefaultsRegistration.Apply(services, defaultExpirationInSeconds: null);
         services.AddScoped(typeof(IPipelineBehavior<,>), typeof(RequestOutputCacheBehavior<,>));
         services.AddScoped(typeof(IPipelineBehavior<,>), typeof(RequestOutputCacheEvictBehavior<,>));
         return services;

--- a/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheConfigurationOption.cs
+++ b/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheConfigurationOption.cs
@@ -41,10 +41,30 @@ public class RequestOutputCacheConfigurationOption
     /// </exception>
     public void UseMemoryCache()
     {
+        UseMemoryCache(_ => { });
+    }
+
+    /// <summary>
+    /// Configures the library to use in-memory caching for MediatR request responses.
+    /// </summary>
+    /// <param name="configure">Action used to configure memory cache provider options.</param>
+    /// <exception cref="ArgumentNullException">Thrown if <paramref name="configure"/> is null.</exception>
+    /// <exception cref="InvalidOperationException">
+    /// Thrown if a cache type has already been configured.
+    /// </exception>
+    public void UseMemoryCache(Action<MemoryRequestOutputCacheOptions> configure)
+    {
+        ArgumentNullException.ThrowIfNull(configure);
+
         if (RequestOutputCacheType != default)
             throw new InvalidOperationException(ErrorMessages.AlreadyConfigured);
 
+        var memoryOptions = new MemoryRequestOutputCacheOptions();
+        configure(memoryOptions);
+
         RequestOutputCacheType = RequestOutputCacheType.MemoryCache;
+
+        RequestOutputCacheDefaultsRegistration.Apply(Services, memoryOptions.DefaultExpirationInSeconds);
 
         Services.AddMemoryCache();
         Services.AddScoped(typeof(IRequestOutputCache<,>), typeof(RequestOutputCache<,>));

--- a/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheDefaults.cs
+++ b/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheDefaults.cs
@@ -1,0 +1,15 @@
+namespace NexGen.MediatR.Extensions.Caching.Configurations;
+
+/// <summary>
+/// Library-wide defaults for MediatR request output caching.
+/// Applied when a <see cref="Attributes.RequestOutputCacheAttribute"/> uses the library expiration constant.
+/// </summary>
+public sealed class RequestOutputCacheDefaults
+{
+    /// <summary>
+    /// Optional default cache lifetime in seconds.
+    /// When set, replaces <see cref="Constants.RequestCacheConstants.DefaultExpirationInSeconds"/>
+    /// for attributes that omit an explicit expiration value (constructor default).
+    /// </summary>
+    public int? DefaultExpirationInSeconds { get; set; }
+}

--- a/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheDefaultsRegistration.cs
+++ b/src/NexGen.MediatR.Extensions.Caching/Configurations/RequestOutputCacheDefaultsRegistration.cs
@@ -1,0 +1,34 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace NexGen.MediatR.Extensions.Caching.Configurations;
+
+/// <summary>
+/// Registers <see cref="RequestOutputCacheDefaults"/> during provider configuration.
+/// </summary>
+public static class RequestOutputCacheDefaultsRegistration
+{
+    /// <summary>
+    /// Ensures a <see cref="RequestOutputCacheDefaults"/> singleton is available, and applies
+    /// <paramref name="defaultExpirationInSeconds"/> when provided.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="defaultExpirationInSeconds">Optional provider-level default expiration.</param>
+    public static void Apply(IServiceCollection services, int? defaultExpirationInSeconds)
+    {
+        ArgumentNullException.ThrowIfNull(services);
+
+        var existing = services.FirstOrDefault(d => d.ServiceType == typeof(RequestOutputCacheDefaults));
+        if (existing?.ImplementationInstance is RequestOutputCacheDefaults instance)
+        {
+            if (defaultExpirationInSeconds.HasValue)
+                instance.DefaultExpirationInSeconds = defaultExpirationInSeconds;
+            return;
+        }
+
+        services.TryAddSingleton(new RequestOutputCacheDefaults
+        {
+            DefaultExpirationInSeconds = defaultExpirationInSeconds
+        });
+    }
+}

--- a/tests/NexGen.MediatR.Extensions.Caching.UnitTest/Configurations/ProviderSpecificCacheOptionsTests.cs
+++ b/tests/NexGen.MediatR.Extensions.Caching.UnitTest/Configurations/ProviderSpecificCacheOptionsTests.cs
@@ -1,0 +1,151 @@
+using FluentResults;
+using MediatR;
+using Microsoft.Extensions.Caching.StackExchangeRedis;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using NexGen.MediatR.Extensions.Caching.Attributes;
+using NexGen.MediatR.Extensions.Caching.Behaviors;
+using NexGen.MediatR.Extensions.Caching.Configurations;
+using NexGen.MediatR.Extensions.Caching.Constants;
+using NexGen.MediatR.Extensions.Caching.Contracts;
+using NexGen.MediatR.Extensions.Caching.Garnet.Configurations;
+using NexGen.MediatR.Extensions.Caching.Redis.Configurations;
+
+namespace NexGen.MediatR.Extensions.Caching.UnitTest.Configurations;
+
+public sealed class ProviderSpecificCacheOptionsTests
+{
+    [Fact]
+    public void UseMemoryCache_WithDefaultExpiration_RegistersDefaults()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatROutputCache(opt =>
+            opt.UseMemoryCache(o => o.DefaultExpirationInSeconds = 600));
+
+        using var provider = services.BuildServiceProvider();
+        var defaults = provider.GetRequiredService<RequestOutputCacheDefaults>();
+
+        Assert.Equal(600, defaults.DefaultExpirationInSeconds);
+    }
+
+    [Fact]
+    public void UseRedisCache_ActionOverload_AppliesInstanceNameAndDatabase()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatROutputCache(opt =>
+            opt.UseRedisCache(o =>
+            {
+                o.ConnectionString = "localhost:6379";
+                o.InstanceName = "my-app:";
+                o.Database = 2;
+                o.DefaultExpirationInSeconds = 120;
+            }));
+
+        using var provider = services.BuildServiceProvider();
+        var redisOptions = provider.GetRequiredService<IOptions<RedisCacheOptions>>().Value;
+        var defaults = provider.GetRequiredService<RequestOutputCacheDefaults>();
+
+        Assert.Equal("my-app:", redisOptions.InstanceName);
+        Assert.NotNull(redisOptions.ConfigurationOptions);
+        Assert.Equal(2, redisOptions.ConfigurationOptions.DefaultDatabase);
+        Assert.Equal(120, defaults.DefaultExpirationInSeconds);
+    }
+
+    [Fact]
+    public void UseGarnetCache_ActionOverload_AppliesInstanceNameAndDatabase()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatROutputCache(opt =>
+            opt.UseGarnetCache(o =>
+            {
+                o.ConnectionString = "localhost:6379";
+                o.InstanceName = "garnet:";
+                o.Database = 3;
+            }));
+
+        using var provider = services.BuildServiceProvider();
+        var redisOptions = provider.GetRequiredService<IOptions<RedisCacheOptions>>().Value;
+
+        Assert.Equal("garnet:", redisOptions.InstanceName);
+        Assert.NotNull(redisOptions.ConfigurationOptions);
+        Assert.Equal(3, redisOptions.ConfigurationOptions.DefaultDatabase);
+    }
+
+    [Fact]
+    public void UseRedisCache_StringOverload_StillRegistersProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddMediatROutputCache(opt => opt.UseRedisCache("localhost:6379"));
+
+        using var provider = services.BuildServiceProvider();
+        var redisOptions = provider.GetRequiredService<IOptions<RedisCacheOptions>>().Value;
+
+        Assert.Equal("localhost:6379", redisOptions.Configuration);
+        Assert.Null(redisOptions.ConfigurationOptions);
+    }
+
+    [Fact]
+    public async Task Behavior_UsesProviderDefault_WhenAttributeUsesLibraryConstant()
+    {
+        var cache = new CapturingCache<CachedQuery>();
+        var behavior = new RequestOutputCacheBehavior<CachedQuery, string>(
+            cache,
+            new RequestOutputCacheDefaults { DefaultExpirationInSeconds = 90 });
+
+        var response = await behavior.Handle(
+            new CachedQuery(1),
+            _ => Task.FromResult("ok"),
+            CancellationToken.None);
+
+        Assert.Equal("ok", response);
+        Assert.Equal(90, cache.LastExpirationInSeconds);
+    }
+
+    [Fact]
+    public async Task Behavior_KeepsExplicitAttributeExpiration()
+    {
+        var cache = new CapturingCache<ExplicitExpirationQuery>();
+        var behavior = new RequestOutputCacheBehavior<ExplicitExpirationQuery, string>(
+            cache,
+            new RequestOutputCacheDefaults { DefaultExpirationInSeconds = 90 });
+
+        await behavior.Handle(
+            new ExplicitExpirationQuery(1),
+            _ => Task.FromResult("ok"),
+            CancellationToken.None);
+
+        Assert.Equal(15, cache.LastExpirationInSeconds);
+    }
+
+    [RequestOutputCache(["tag"])]
+    private sealed record CachedQuery(int Id) : IRequest<string>;
+
+    [RequestOutputCache(["tag"], expirationInSeconds: 15)]
+    private sealed record ExplicitExpirationQuery(int Id) : IRequest<string>;
+
+    private sealed class CapturingCache<TRequest> : IRequestOutputCache<TRequest, string>
+        where TRequest : IRequest<string>
+    {
+        public int? LastExpirationInSeconds { get; private set; }
+
+        public Task<Result<string>> GetAsync(TRequest request, CancellationToken cancellationToken = default)
+            => Task.FromResult(Result.Fail<string>(ErrorMessages.ResponseNotFound));
+
+        public Task<Result> SetAsync(
+            TRequest request,
+            string response,
+            IEnumerable<string>? tags = null,
+            int expirationInSeconds = default,
+            CancellationToken cancellationToken = default)
+        {
+            LastExpirationInSeconds = expirationInSeconds;
+            return Task.FromResult(Result.Ok());
+        }
+
+        public Task<Result> EvictByTagsAsync(IEnumerable<string> tags, CancellationToken cancellationToken = default)
+            => Task.FromResult(Result.Ok());
+
+        public Task<Result> FlushAll(CancellationToken cancellationToken = default)
+            => Task.FromResult(Result.Ok());
+    }
+}

--- a/tests/NexGen.MediatR.Extensions.Caching.UnitTest/NexGen.MediatR.Extensions.Caching.UnitTest.csproj
+++ b/tests/NexGen.MediatR.Extensions.Caching.UnitTest/NexGen.MediatR.Extensions.Caching.UnitTest.csproj
@@ -27,6 +27,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\src\NexGen.MediatR.Extensions.Caching\NexGen.MediatR.Extensions.Caching.csproj" />
+    <ProjectReference Include="..\..\src\NexGen.MediatR.Extensions.Caching.Redis\NexGen.MediatR.Extensions.Caching.Redis.csproj" />
+    <ProjectReference Include="..\..\src\NexGen.MediatR.Extensions.Caching.Garnet\NexGen.MediatR.Extensions.Caching.Garnet.csproj" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Adds Action-based `UseMemoryCache` / `UseRedisCache` / `UseGarnetCache` overloads for provider-specific options (`InstanceName`, `Database`, `ConfigurationOptions`, `DefaultExpirationInSeconds`).
- Keeps existing string and parameterless APIs (they delegate to the new overloads).
- Documents TTL precedence and covers behavior with unit tests.

Closes #34

## Test plan
- [x] `dotnet build` Release
- [x] `dotnet test` UnitTest (net8/net9/net10)
- [ ] CI green on PR