### PR TITLE
Remove sync-over-async in eviction path (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ Package versions for **core**, **Redis**, **Garnet**, and **EntityFramework** ar
 
 ## [Unreleased]
 
+### Fixed
+
+- Memory / Redis / Garnet: remove sync-over-async (`.Result`) in tag eviction path (#51).
+
 ## [1.4.3] - 2026-08-11
 
 ### Fixed

--- a/src/NexGen.MediatR.Extensions.Caching.Garnet/GarnetRequestOutputCache.cs
+++ b/src/NexGen.MediatR.Extensions.Caching.Garnet/GarnetRequestOutputCache.cs
@@ -91,13 +91,15 @@ public sealed class GarnetRequestOutputCache<TRequest, TResponse>
     {
         try
         {
+            var cacheTags = await _cacheContainer.GetCacheTagsAsync(cancellationToken).ConfigureAwait(false);
+
             foreach (var tag in tags)
             {
-                if (!_cacheContainer.GetCacheTagsAsync(cancellationToken).Result.TryGetValue(tag, out HashSet<string>? tagTypes))
+                if (!cacheTags.TryGetValue(tag, out HashSet<string>? tagTypes))
                     continue;
 
                 tagTypes ??= [];
-                await EvictTypesAsync(tagTypes, cancellationToken);
+                await EvictTypesAsync(tagTypes, cancellationToken).ConfigureAwait(false);
             }
 
             return Result.Ok();
@@ -142,12 +144,14 @@ public sealed class GarnetRequestOutputCache<TRequest, TResponse>
     /// <returns>A successful <see cref="Result"/> when eviction completes.</returns>
     private async Task<Result> EvictTypesAsync(HashSet<string> tagTypes, CancellationToken cancellationToken = default)
     {
+        var cacheTypes = await _cacheContainer.GetCacheTypesAsync(cancellationToken).ConfigureAwait(false);
+
         foreach (var tagType in tagTypes)
         {
-            if (!_cacheContainer.GetCacheTypesAsync(cancellationToken).Result.TryGetValue(tagType, out HashSet<string?>? cacheTypes) || cacheTypes is null)
+            if (!cacheTypes.TryGetValue(tagType, out HashSet<string?>? types) || types is null)
                 continue;
 
-            foreach (var cacheType in cacheTypes)
+            foreach (var cacheType in types)
             {
                 if (cacheType is not null)
                     await _cache.RemoveAsync(cacheType, cancellationToken);

--- a/src/NexGen.MediatR.Extensions.Caching.Redis/RedisRequestOutputCache.cs
+++ b/src/NexGen.MediatR.Extensions.Caching.Redis/RedisRequestOutputCache.cs
@@ -95,13 +95,15 @@ public sealed class RedisRequestOutputCache<TRequest, TResponse>
     {
         try
         {
+            var cacheTags = await _cacheContainer.GetCacheTagsAsync(cancellationToken).ConfigureAwait(false);
+
             foreach (var tag in tags)
             {
-                if (!_cacheContainer.GetCacheTagsAsync(cancellationToken).Result.TryGetValue(tag, out HashSet<string>? tagTypes))
+                if (!cacheTags.TryGetValue(tag, out HashSet<string>? tagTypes))
                     continue;
 
                 tagTypes ??= [];
-                await EvictTypesAsync(tagTypes, cancellationToken);
+                await EvictTypesAsync(tagTypes, cancellationToken).ConfigureAwait(false);
             }
 
             return Result.Ok();
@@ -146,12 +148,14 @@ public sealed class RedisRequestOutputCache<TRequest, TResponse>
     /// <returns>A successful <see cref="Result"/> when eviction completes.</returns>
     private async Task<Result> EvictTypesAsync(HashSet<string> tagTypes, CancellationToken cancellationToken = default)
     {
+        var cacheTypes = await _cacheContainer.GetCacheTypesAsync(cancellationToken).ConfigureAwait(false);
+
         foreach (var tagType in tagTypes)
         {
-            if (!_cacheContainer.GetCacheTypesAsync(cancellationToken).Result.TryGetValue(tagType, out HashSet<string?>? cacheTypes) || cacheTypes is null)
+            if (!cacheTypes.TryGetValue(tagType, out HashSet<string?>? types) || types is null)
                 continue;
 
-            foreach (var cacheType in cacheTypes)
+            foreach (var cacheType in types)
             {
                 if (cacheType is not null)
                     await _cache.RemoveAsync(cacheType, cancellationToken);

--- a/src/NexGen.MediatR.Extensions.Caching/RequestOutputCache.cs
+++ b/src/NexGen.MediatR.Extensions.Caching/RequestOutputCache.cs
@@ -89,13 +89,15 @@ public sealed class RequestOutputCache<TRequest, TResponse>
     {
         try
         {
+            var cacheTags = await _cacheContainer.GetCacheTagsAsync(cancellationToken).ConfigureAwait(false);
+
             foreach (var tag in tags)
             {
-                if (!_cacheContainer.GetCacheTagsAsync(cancellationToken).Result.TryGetValue(tag, out HashSet<string>? tagTypes))
+                if (!cacheTags.TryGetValue(tag, out HashSet<string>? tagTypes))
                     continue;
 
                 tagTypes ??= [];
-                await EvictTypesAsync(tagTypes, cancellationToken);
+                await EvictTypesAsync(tagTypes, cancellationToken).ConfigureAwait(false);
             }
 
             return Result.Ok();
@@ -140,12 +142,14 @@ public sealed class RequestOutputCache<TRequest, TResponse>
     /// <returns>A successful <see cref="Result"/> when eviction completes.</returns>
     private async Task<Result> EvictTypesAsync(HashSet<string> tagTypes, CancellationToken cancellationToken = default)
     {
+        var cacheTypes = await _cacheContainer.GetCacheTypesAsync(cancellationToken).ConfigureAwait(false);
+
         foreach (var tagType in tagTypes.TakeWhile(_ => !cancellationToken.IsCancellationRequested))
         {
-            if (!_cacheContainer.GetCacheTypesAsync(cancellationToken).Result.TryGetValue(tagType, out HashSet<string?>? cacheTypes) || cacheTypes is null)
+            if (!cacheTypes.TryGetValue(tagType, out HashSet<string?>? types) || types is null)
                 continue;
 
-            foreach (var cacheType in cacheTypes)
+            foreach (var cacheType in types)
             {
                 if (cacheType is not null)
                     _memoryCache.Remove(cacheType);


### PR DESCRIPTION
## Summary

- Replace `.Result` blocking calls on `IRequestOutputCacheContainer` with proper `await` in `EvictByTagsAsync` and `EvictTypesAsync` across Memory, Redis, and Garnet providers.
- Fetch container indexes once per eviction call instead of per tag/type lookup (same behavior, fewer round-trips).

Fixes #51

## Test plan

- [x] `dotnet build NexGen.MediatR.Extensions.Caching.sln -c Release`
- [x] `dotnet test NexGen.MediatR.Extensions.Caching.sln -c Release --no-build` (58 tests × net8/net9/net10)
